### PR TITLE
Allow broker to display in apps manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 out
 
+.idea/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 27 00:37:02 MDT 2014
+#Fri Sep 25 22:12:15 CDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/src/main/java/com/mattstine/cf/haash/model/Metadata.java
+++ b/src/main/java/com/mattstine/cf/haash/model/Metadata.java
@@ -1,0 +1,12 @@
+package com.mattstine.cf.haash.model;
+
+public class Metadata {
+
+    public String displayName = "HaashBroker";
+    public String imageUrl = "http://i.ytimg.com/vi/1plPyJdXKIY/mqdefault.jpg";
+    public String longDescription = "Hash map as a service";
+    public String documentationUrl =
+            "https://www.youtube.com/watch?v=1plPyJdXKIY";
+    public String supportUrl = "https://www.youtube.com/watch?v=1plPyJdXKIY";
+
+}

--- a/src/main/java/com/mattstine/cf/haash/model/Service.java
+++ b/src/main/java/com/mattstine/cf/haash/model/Service.java
@@ -24,6 +24,17 @@ public class Service {
     @JoinColumn(name = "service_id")
     private Set<Plan> plans = new HashSet<>();
 
+    @Transient
+    private final Metadata metadata;
+
+    public Service() {
+        this.metadata = new Metadata();
+    }
+
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
     public String getId() {
         return id;
     }

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,2 +1,2 @@
 insert into services (id, name, description, bindable) values (LOCALTIME, LOCALTIME, 'HaaSh - HashMap as a Service', true);
-insert into plans (id, name, description, service_id) values ('1', 'basic', 'Basic Plan', LOCALTIME);
+insert into plans (id, name, description, service_id) values (LOCALTIME, 'basic', 'Basic Plan', LOCALTIME);

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,2 +1,2 @@
-insert into services (id, name, description, bindable) values ('1', 'HaaSh', 'HaaSh - HashMap as a Service', true)
-insert into plans (id, name, description, service_id) values ('1', 'basic', 'Basic Plan','1');
+insert into services (id, name, description, bindable) values (LOCALTIME, LOCALTIME, 'HaaSh - HashMap as a Service', true);
+insert into plans (id, name, description, service_id) values ('1', 'basic', 'Basic Plan', LOCALTIME);


### PR DESCRIPTION
Hi Matt, 
I made a couple of changes to the broker. The first is to add metadata to allow the broker to show up in console with images and support links etc. The second uses time to give the broker a unique ID so multiple people can register it (I use the broker in workshops). 

Not sure if you have interest in including or not, but if so here they are!
